### PR TITLE
Add support for ProjectReferences and remove transitive walk

### DIFF
--- a/src/PackageShading.Tasks.UnitTests/MockNuGetAssetFileLoader.cs
+++ b/src/PackageShading.Tasks.UnitTests/MockNuGetAssetFileLoader.cs
@@ -4,6 +4,19 @@ namespace PackageShading.Tasks.UnitTests
 {
     internal class MockNuGetAssetFileLoader : Dictionary<string, Dictionary<PackageIdentity, HashSet<PackageIdentity>>>, INuGetAssetFileLoader
     {
-        public Dictionary<string, Dictionary<PackageIdentity, HashSet<PackageIdentity>>> LoadAssetsFile(string projectAssetsFile) => this;
+        public NuGetAssetsFile LoadAssetsFile(string projectDirectory, string projectAssetsFile)
+        {
+            NuGetAssetsFile assetsFile = new NuGetAssetsFile();
+
+            foreach (var item in this)
+            {
+                foreach (var package in item.Value)
+                {
+                    assetsFile[item.Key].Packages[package.Key] = package.Value;
+                }
+            }
+
+            return assetsFile;
+        }
     }
 }

--- a/src/PackageShading.Tasks.UnitTests/NuGetAssetFileLoaderTests.cs
+++ b/src/PackageShading.Tasks.UnitTests/NuGetAssetFileLoaderTests.cs
@@ -8,6 +8,14 @@ namespace PackageShading.Tasks.UnitTests
     public class NuGetAssetFileLoaderTests : TestBase
     {
         [Fact]
+        public void Test1()
+        {
+            INuGetAssetFileLoader nuGetAssetFileLoader = new NuGetAssetFileLoader();
+
+            NuGetAssetsFile p = nuGetAssetFileLoader.LoadAssetsFile(@"D:\Repros\azure-functions-dotnet-worker\extensions\Worker.Extensions.ServiceBus\Worker.Extensions.ServiceBus.csproj", @"D:\Repros\azure-functions-dotnet-worker\extensions\Worker.Extensions.ServiceBus\src\obj\project.assets.json");
+        }
+
+        [Fact]
         public void TransitiveDependenciesAreCorrectlyLoaded()
         {
             string projectAssetsFile = Path.Combine(TestDirectory, "project.assets.json");
@@ -226,7 +234,7 @@ namespace PackageShading.Tasks.UnitTests
 
             INuGetAssetFileLoader nuGetAssetFileLoader = new NuGetAssetFileLoader();
 
-            Dictionary<string, Dictionary<PackageIdentity, HashSet<PackageIdentity>>> assetsFile = nuGetAssetFileLoader.LoadAssetsFile(projectAssetsFile);
+            var assetsFile = nuGetAssetFileLoader.LoadAssetsFile(string.Empty, projectAssetsFile);
 
             assetsFile.Keys.ShouldBe(new[]
             {
@@ -244,9 +252,9 @@ namespace PackageShading.Tasks.UnitTests
             PackageIdentity packageNuGetFrameworks = new PackageIdentity("NuGet.Frameworks", "5.11.0");
             PackageIdentity packageSystemReflectionMetadata = new PackageIdentity("System.Reflection.Metadata", "1.6.0");
 
-            Dictionary<PackageIdentity, HashSet<PackageIdentity>> net472Packages = assetsFile[".NETFramework,Version=v4.7.2"];
+            NuGetAssetsFileSection net472Section = assetsFile[".NETFramework,Version=v4.7.2"];
 
-            net472Packages.Keys.ShouldBe(new[]
+            net472Section.Packages.Keys.ShouldBe(new[]
             {
                 packageMicrosoftCodeCoverage,
                 packageMicrosoftNETTestSdk,
@@ -254,23 +262,23 @@ namespace PackageShading.Tasks.UnitTests
                 packageNewtonsoftJsonBson
             });
 
-            net472Packages[packageMicrosoftCodeCoverage].ShouldBe(new HashSet<PackageIdentity>());
+            net472Section.Packages[packageMicrosoftCodeCoverage].ShouldBe(new HashSet<PackageIdentity>());
 
-            net472Packages[packageMicrosoftNETTestSdk].ShouldBe(new HashSet<PackageIdentity>
+            net472Section.Packages[packageMicrosoftNETTestSdk].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageMicrosoftCodeCoverage
             });
 
-            net472Packages[packageNewtonsoftJson12].ShouldBe(new HashSet<PackageIdentity>());
+            net472Section.Packages[packageNewtonsoftJson12].ShouldBe(new HashSet<PackageIdentity>());
 
-            net472Packages[packageNewtonsoftJsonBson].ShouldBe(new HashSet<PackageIdentity>
+            net472Section.Packages[packageNewtonsoftJsonBson].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageNewtonsoftJson12
             });
 
-            Dictionary<PackageIdentity, HashSet<PackageIdentity>> net60Packages = assetsFile["net6.0"];
+            var net60Section = assetsFile["net6.0"];
 
-            net60Packages.Keys.ShouldBe(new[]
+            net60Section.Packages.Keys.ShouldBe(new[]
             {
                 packageMicrosoftCodeCoverage,
                 packageMicrosoftNETTestSdk,
@@ -282,9 +290,9 @@ namespace PackageShading.Tasks.UnitTests
                 packageSystemReflectionMetadata
             });
 
-            net60Packages[packageMicrosoftCodeCoverage].ShouldBe(new HashSet<PackageIdentity>());
+            net60Section.Packages[packageMicrosoftCodeCoverage].ShouldBe(new HashSet<PackageIdentity>());
 
-            net60Packages[packageMicrosoftNETTestSdk].ShouldBe(new HashSet<PackageIdentity>
+            net60Section.Packages[packageMicrosoftNETTestSdk].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageMicrosoftCodeCoverage,
                 packageMicrosoftTestPlatformTestHost,
@@ -294,13 +302,13 @@ namespace PackageShading.Tasks.UnitTests
                 packageSystemReflectionMetadata
             });
 
-            net60Packages[packageMicrosoftTestPlatformObjectModel].ShouldBe(new HashSet<PackageIdentity>
+            net60Section.Packages[packageMicrosoftTestPlatformObjectModel].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageNuGetFrameworks,
                 packageSystemReflectionMetadata
             });
 
-            net60Packages[packageMicrosoftTestPlatformTestHost].ShouldBe(new HashSet<PackageIdentity>
+            net60Section.Packages[packageMicrosoftTestPlatformTestHost].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageMicrosoftTestPlatformObjectModel,
                 packageNewtonsoftJson9,
@@ -308,16 +316,16 @@ namespace PackageShading.Tasks.UnitTests
                 packageSystemReflectionMetadata
             });
 
-            net60Packages[packageNewtonsoftJson12].ShouldBe(new HashSet<PackageIdentity>());
+            net60Section.Packages[packageNewtonsoftJson12].ShouldBe(new HashSet<PackageIdentity>());
 
-            net60Packages[packageNewtonsoftJsonBson].ShouldBe(new HashSet<PackageIdentity>
+            net60Section.Packages[packageNewtonsoftJsonBson].ShouldBe(new HashSet<PackageIdentity>
             {
                 packageNewtonsoftJson12
             });
 
-            net60Packages[packageNuGetFrameworks].ShouldBe(new HashSet<PackageIdentity>());
+            net60Section.Packages[packageNuGetFrameworks].ShouldBe(new HashSet<PackageIdentity>());
 
-            net60Packages[packageSystemReflectionMetadata].ShouldBe(new HashSet<PackageIdentity>());
+            net60Section.Packages[packageSystemReflectionMetadata].ShouldBe(new HashSet<PackageIdentity>());
         }
     }
 }

--- a/src/PackageShading.Tasks/INuGetAssetFileLoader.cs
+++ b/src/PackageShading.Tasks/INuGetAssetFileLoader.cs
@@ -12,6 +12,6 @@ namespace PackageShading.Tasks
         /// </summary>
         /// <param name="projectAssetsFile">The full path to the NuGet assests file to load.</param>
         /// <returns>An <see cref="Dictionary{TKey, TValue}" /> containing target frameworks and a list of packages with their dependencies.</returns>
-        Dictionary<string, Dictionary<PackageIdentity, HashSet<PackageIdentity>>> LoadAssetsFile(string projectAssetsFile);
+        NuGetAssetsFile LoadAssetsFile(string projectDirectory, string projectAssetsFile);
     }
 }

--- a/src/PackageShading.Tasks/NuGetAssetsFile.cs
+++ b/src/PackageShading.Tasks/NuGetAssetsFile.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace PackageShading.Tasks
+{
+    public sealed class NuGetAssetsFile : Dictionary<string, NuGetAssetsFileSection>
+    {
+        public NuGetAssetsFile()
+            : base(StringComparer.OrdinalIgnoreCase)
+        {
+        }
+
+        public Dictionary<string, PackageIdentity> ProjectReferences { get; } = new();
+    }
+}

--- a/src/PackageShading.Tasks/NuGetAssetsFileSection.cs
+++ b/src/PackageShading.Tasks/NuGetAssetsFileSection.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace PackageShading.Tasks
+{
+    public sealed class NuGetAssetsFileSection
+    {
+        public Dictionary<PackageIdentity, HashSet<PackageIdentity>> Packages { get; } = new Dictionary<PackageIdentity, HashSet<PackageIdentity>>();
+    }
+}

--- a/src/PackageShading.Tasks/PackageAssemblyResolver.cs
+++ b/src/PackageShading.Tasks/PackageAssemblyResolver.cs
@@ -15,6 +15,11 @@ namespace PackageShading.Tasks
         {
             string path = Path.Combine(nuGetPackageRoot, packageIdentity.Id.ToLower(), packageIdentity.Version.ToLower(), "lib");
 
+            if (!Directory.Exists(path))
+            {
+                return null;
+            }
+
             IEnumerable<string> targetFrameworksToCheck = new List<string> { targetFramework }.Concat(fallbackTargetFrameworks == null ? Array.Empty<string>() : fallbackTargetFrameworks);
 
             List<DirectoryInfo> compatibleTargetFrameworks = Directory.EnumerateDirectories(path).Select(i => new DirectoryInfo(i)).ToList();

--- a/src/PackageShading.Tasks/build/PackageShading.Tasks.Common.targets
+++ b/src/PackageShading.Tasks/build/PackageShading.Tasks.Common.targets
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <Target Name="GetAssembliesToShade"
-          DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn)"
+          DependsOnTargets="$(ResolveAssemblyReferencesDependsOn)"
           Returns="@(_AssembliesToShade)">
     <GetAssembliesToShade Debug="$(DebugShadeAssemblies)"
                           FallbackTargetFrameworks="$(AssetTargetFallback)"
@@ -17,7 +17,9 @@
                           PackageReferences="@(PackageReference)"
                           PackageVersions="@(PackageVersion)"
                           ProjectAssetsFile="$(ProjectAssetsFile)"
-                          References="@(Reference)"
+                          ProjectDirectory="$(MSBuildProjectDirectory)"
+                          ProjectReferences="@(ProjectReference)"
+                          References="@(Reference);@(_ResolvedProjectReferencePaths)"
                           ShadedAssemblyKeyFile="$(ShadedAssemblyKeyFile)"
                           TargetFramework="$(TargetFramework)"
                           TargetFrameworkMoniker="$(TargetFrameworkMoniker)">
@@ -25,6 +27,8 @@
       <Output TaskParameter="AssembliesToShade" ItemName="FileWrites" />
       <Output TaskParameter="ReferencesToRemove" ItemName="_ReferencesToRemove" />
       <Output TaskParameter="ReferencesToAdd" ItemName="_ReferencesToAdd" />
+      <Output TaskParameter="ProjectReferencesToRemove" ItemName="_ProjectReferencesToRemove" />
+      <Output TaskParameter="ProjectReferencesToAdd" ItemName="_ProjectReferencesToAdd" />
     </GetAssembliesToShade>
 
     <ItemGroup>
@@ -33,6 +37,9 @@
       
       <Reference Remove="@(_ReferencesToRemove)" />
       <Reference Include="@(_ReferencesToAdd)" />
+
+      <_ResolvedProjectReferencePaths Remove="@(_ProjectReferencesToRemove)" />
+      <_ResolvedProjectReferencePaths Include="@(_ProjectReferencesToAdd)" />
       
       <TfmSpecificPackageFile Include="@(_AssembliesToShade)"
                               Pack="true"
@@ -42,8 +49,8 @@
   </Target>
 
   <Target Name="ShadeAssemblies"
-          DependsOnTargets="$(ResolvePackageDependenciesForBuildDependsOn);GetAssembliesToShade"
-          AfterTargets="ResolvePackageDependenciesForBuild"
+          DependsOnTargets="$(ResolveAssemblyReferencesDependsOn);GetAssembliesToShade"
+          BeforeTargets="ResolveAssemblyReferences"
           Inputs="@(_AssembliesToShade->'%(OriginalPath)');$(MSBuildAllProjects)"
           Outputs="@(_AssembliesToShade)"
           Condition="'$(DesignTimeBuild)' != 'true' And '$(ShadeAssemblies)' != 'false'">


### PR DESCRIPTION
You now have to set `Shade="true"` and `ShadeDependencies="*"` to shade a package and all of its dependencies.  Otherwise you can specify individual dependencies to shade